### PR TITLE
Ok, so I got your tests running, but I had to do several changes, here a...

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "karma": "^0.12.31",
     "karma-ie-launcher": "^0.1.5",
     "karma-junit-reporter": "^0.2.2",
+    "karma-chrome-launcher": "^0.1.4",
+    "karma-jasmine": "^0.1.5",
     "protractor": "^1.1.1",
     "shelljs": "^0.2.6"
   },
@@ -19,7 +21,7 @@
     "prestart": "npm install",
     "start": "http-server -a localhost -p 8000 -c-1",
     "pretest": "npm install",
-    "test": "karma start karma.conf.js",
+    "test": "node node_modules/karma/bin/karma start karma.conf.js",
     "test-single-run": "karma start karma.conf.js  --single-run",
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",

--- a/tests/example.js
+++ b/tests/example.js
@@ -13,15 +13,22 @@
 describe('taskListApp controllers', function() {
 
     describe('taskController', function() {
-        var scope;//, ctrl;
-        beforeEach(inject(function($rootScope, $controller) {
-            scope = $rootScope.$new();
-           // ctrl = $controller('taskController', {$scope: scope})
-        }));
+        var scope, ctrl;
+        beforeEach(
+			function(){
+				module('tasklist', function () {});
+				inject(function($rootScope, $controller) {
+				
+
+					scope = $rootScope.$new();
+					ctrl = $controller('taskController', {$scope: scope})
+				})
+			}
+		);
 
     describe('Managing Lists', function () {
         it('should not have a new List on start', function () {
-            expect(scope.tasks.size()).toBe(0);
+            expect(scope.tasks.length).toBe(0);
         });
 
         //    it('should have default List on start', function () {


### PR DESCRIPTION
...re the highlights:

1.	You did not include karma-jasmine in your package.json, so it couldn’t run jasmine unit-tests at all.
2.	The ‘test’ cmd in the package.json assumed that you have karma installed globally. It didn’t work on my machine because I don’t have it globally, so I modified the path in the json file.
3.	The controller creation in the test was commented out, I assume this is because it wasn’t recognized by the test. What was missing is the module declaration, and I had to change the structure of the beforeEach function for that because the module has to be created before the inject function.
4.	Finally, the test itself – arrays in JS do not have a size() function but rather a length property.